### PR TITLE
fix compilation on rust 1.58.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(allocator_api)]
+
 extern crate libc;
 extern crate time;
 


### PR DESCRIPTION
Fix error:

```
error[E0658]: use of unstable library feature 'allocator_api'
 --> /hdd/home/chabapok-hdd/.cargo/git/checkouts/tracing_allocator-d033f2a645d2f0f0/c550a7d/src/lib.rs:8:47
  |
8 | use std::alloc::{GlobalAlloc, System, Layout, AllocError};
  |                                               ^^^^^^^^^^
  |
  = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
  = help: add `#![feature(allocator_api)]` to the crate attributes to enable

```